### PR TITLE
Prevent multiple-initialization of WorkManager

### DIFF
--- a/app/src/main/java/tech/bigfig/roma/RomaApplication.java
+++ b/app/src/main/java/tech/bigfig/roma/RomaApplication.java
@@ -106,7 +106,7 @@ public class RomaApplication extends Application implements HasAndroidInjector {
 
     }
 
-    private void initWorkManager() {
+    public void initWorkManager() {
         androidx.work.Configuration config = new androidx.work.Configuration.Builder()
                 .setWorkerFactory(new DaggerWorkerFactory()) // Overrides default WorkerFactory
                 .build();

--- a/app/src/test/java/tech/bigfig/roma/FakeRomaApplication.kt
+++ b/app/src/test/java/tech/bigfig/roma/FakeRomaApplication.kt
@@ -16,6 +16,10 @@ class FakeRomaApplication : RomaApplication() {
         // No-op
     }
 
+    override fun initWorkManager() {
+        // No-op
+    }
+
     override fun getServiceLocator(): ServiceLocator {
         return locator
     }


### PR DESCRIPTION
Per this issue: https://github.com/robolectric/robolectric/issues/4788

Problem:
* Multiple initializations of WorkManager causes app to crash, all but first test to fail.
* Robolectric re-inits app before each test, so multiple-inits are called.

Fix:
* Made initWorkManager() public in RomaApplication.
* No-op’ed in FakeRomaApplication.