### PR TITLE
Add a (La)debug to app_name

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,10 +35,12 @@ android {
             minifyEnabled true
             shrinkResources true
             proguardFiles 'proguard-rules.pro'
+            resValue "string", "app_name", "Roma"
         }
         debug {
             //Disable crashlytics for debug builds
             ext.enableCrashlytics = false
+            resValue "string", "app_name", "Roma 🐞"
         }
     }
 

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">Roma</string>
     <string name="app_website" translatable="false">https://romaapp.github.io/</string>
 
     <string name="oauth_scheme" translatable="false">oauth2redirect</string>


### PR DESCRIPTION
For debug builds only; to visually distinguish the launcher icon in the app tray when the beta/production app is installed alongside.

![Screen Shot 2019-07-03 at 14 13 52](https://user-images.githubusercontent.com/6524043/60594416-d2497800-9d9c-11e9-8ffc-af7e9e145950.png)
