### PR TITLE
Renamed layout reference to BackgroundMessageView

### DIFF
--- a/app/src/main/res/layout-sw640dp/fragment_timeline_notifications.xml
+++ b/app/src/main/res/layout-sw640dp/fragment_timeline_notifications.xml
@@ -75,7 +75,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center" />
 
-        <comtech.bigfig.roma.view.BackgroundMessageView
+        <tech.bigfig.roma.view.BackgroundMessageView
             android:id="@+id/statusView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
“comtech.” was erroneously given as the TLP. Corrected to just “tech.”