### PR TITLE
Switch from `conversations` to `timelines/direct` without DB changes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,10 +47,7 @@ android {
     flavorDimensions "color"
     productFlavors {
         blue {}
-        green {
-            //applicationIdSuffix ".test"
-            versionNameSuffix " [" + getGitSha() + "]"
-        }
+        green {}
     }
 
     lintOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -139,8 +139,6 @@ dependencies {
     kapt 'androidx.room:room-compiler:2.1.0'
     implementation 'androidx.room:room-rxjava2:2.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1'
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.1"
     implementation "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
     implementation "com.google.dagger:dagger-android:$daggerVersion"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -139,6 +139,8 @@ dependencies {
     kapt 'androidx.room:room-compiler:2.1.0'
     implementation 'androidx.room:room-rxjava2:2.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.1"
     implementation "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
     implementation "com.google.dagger:dagger-android:$daggerVersion"

--- a/app/src/main/java/tech/bigfig/roma/components/conversation/ConversationEntity.kt
+++ b/app/src/main/java/tech/bigfig/roma/components/conversation/ConversationEntity.kt
@@ -160,6 +160,7 @@ data class ConversationStatusEntity(
                 pinned = false,
                 poll = poll,
                 card = null,
+                pleroma = null,
                 repliesCount = 0)
     }
 }

--- a/app/src/main/java/tech/bigfig/roma/components/conversation/ConversationsBoundaryCallback.kt
+++ b/app/src/main/java/tech/bigfig/roma/components/conversation/ConversationsBoundaryCallback.kt
@@ -18,14 +18,14 @@ package tech.bigfig.roma.components.conversation
 
 import androidx.annotation.MainThread
 import androidx.paging.PagedList
-import tech.bigfig.roma.entity.Conversation
-import tech.bigfig.roma.util.PagingRequestHelper
-import tech.bigfig.roma.util.createStatusLiveData
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+import tech.bigfig.roma.entity.Conversation
 import tech.bigfig.roma.entity.Status
 import tech.bigfig.roma.network.MastodonApi
+import tech.bigfig.roma.util.PagingRequestHelper
+import tech.bigfig.roma.util.createStatusLiveData
 import java.util.concurrent.Executor
 
 /**

--- a/app/src/main/java/tech/bigfig/roma/components/conversation/ConversationsRepository.kt
+++ b/app/src/main/java/tech/bigfig/roma/components/conversation/ConversationsRepository.kt
@@ -1,24 +1,30 @@
 package tech.bigfig.roma.components.conversation
 
+import android.util.Log
 import androidx.annotation.MainThread
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
 import androidx.paging.Config
 import androidx.paging.toLiveData
-import tech.bigfig.roma.entity.Conversation
-import tech.bigfig.roma.util.Listing
-import tech.bigfig.roma.util.NetworkState
 import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 import tech.bigfig.roma.db.AppDatabase
+import tech.bigfig.roma.entity.Account
+import tech.bigfig.roma.entity.Conversation
+import tech.bigfig.roma.entity.Status
 import tech.bigfig.roma.network.MastodonApi
+import tech.bigfig.roma.util.Listing
+import tech.bigfig.roma.util.NetworkState
+import java.util.*
 import java.util.concurrent.Executors
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.collections.ArrayList
+import kotlin.collections.HashMap
 
 @Singleton
 class ConversationsRepository @Inject constructor(val mastodonApi: MastodonApi, val db: AppDatabase) {
@@ -32,30 +38,70 @@ class ConversationsRepository @Inject constructor(val mastodonApi: MastodonApi, 
     @MainThread
     fun refresh(accountId: Long, showLoadingIndicator: Boolean): LiveData<NetworkState> {
         val networkState = MutableLiveData<NetworkState>()
-        if(showLoadingIndicator) {
+        if (showLoadingIndicator) {
             networkState.value = NetworkState.LOADING
         }
 
-        mastodonApi.getConversations(null, DEFAULT_PAGE_SIZE).enqueue(
-                object : Callback<List<Conversation>> {
-                    override fun onFailure(call: Call<List<Conversation>>, t: Throwable) {
+        mastodonApi.getTimelineDirect(null, null, DEFAULT_PAGE_SIZE).enqueue(
+                object : Callback<List<Status>> {
+                    override fun onFailure(call: Call<List<Status>>, t: Throwable) {
+
                         // retrofit calls this on main thread so safe to call set value
                         networkState.value = NetworkState.error(t.message)
                     }
 
-                    override fun onResponse(call: Call<List<Conversation>>, response: Response<List<Conversation>>) {
+                    override fun onResponse(call: Call<List<Status>>, response: Response<List<Status>>) {
                         ioExecutor.execute {
                             db.runInTransaction {
                                 db.conversationDao().deleteForAccount(accountId)
-                                insertResultIntoDb(accountId, response.body())
+                                insertResultIntoDb(accountId, statusesToConversations(response.body()))
                             }
+
                             // since we are in bg thread now, post the result.
                             networkState.postValue(NetworkState.LOADED)
                         }
                     }
                 }
         )
+
         return networkState
+    }
+
+    private fun statusesToConversations(body: List<Status>?): List<Conversation> {
+
+        val conversations = HashMap<String, Status>()
+        val conversationsRecentFirst = HashMap<Date, Status>()
+
+        body?.reversed()?.iterator()?.forEach { it.pleroma?.conversation_id?.let { id -> conversations[id] = it } }
+
+        conversations.forEach { conversationsRecentFirst[it.value.createdAt] = it.value }
+
+        val conversationList = ArrayList<Conversation>()
+
+        conversationsRecentFirst.toSortedMap(reverseOrder()).forEach {
+            conversationList.add(
+                    Conversation(
+                            id = it.value.pleroma?.conversation_id!!,
+                            accounts = emptyList(),
+                            lastStatus = it.value,
+                            unread = false
+                    )
+            )
+        }
+
+        conversationList.forEach {
+            Log.v("SFG", "Conversation -> $it")
+        }
+
+        return conversationList
+    }
+
+    fun getAccountObjects(mentions: Array<Status.Mention>): List<Account> {
+        val accounts = ArrayList<Account>()
+        mentions.forEach {
+            mastodonApi.account(it.id).execute().body()?.let { it1 -> accounts.add(it1) }
+        }
+        return accounts
     }
 
     @MainThread
@@ -65,7 +111,7 @@ class ConversationsRepository @Inject constructor(val mastodonApi: MastodonApi, 
         val boundaryCallback = ConversationsBoundaryCallback(
                 accountId = accountId,
                 mastodonApi = mastodonApi,
-                handleResponse = this::insertResultIntoDb,
+                handleResponse = this::insertTimelineDirectResultIntoDb,
                 ioExecutor = ioExecutor,
                 networkPageSize = DEFAULT_PAGE_SIZE)
         // we are using a mutable live data to trigger refresh requests which eventually calls
@@ -77,7 +123,7 @@ class ConversationsRepository @Inject constructor(val mastodonApi: MastodonApi, 
         }
 
         // We use toLiveData Kotlin extension function here, you could also use LivePagedListBuilder
-        val livePagedList =  db.conversationDao().conversationsForAccount(accountId).toLiveData(
+        val livePagedList = db.conversationDao().conversationsForAccount(accountId).toLiveData(
                 config = Config(pageSize = DEFAULT_PAGE_SIZE, prefetchDistance = DEFAULT_PAGE_SIZE / 2, enablePlaceholders = false),
                 boundaryCallback = boundaryCallback
         )
@@ -102,9 +148,13 @@ class ConversationsRepository @Inject constructor(val mastodonApi: MastodonApi, 
                 .subscribe()
     }
 
+    private fun insertTimelineDirectResultIntoDb(accountId: Long, list: List<Status>?) {
+        insertResultIntoDb(accountId, statusesToConversations(list))
+    }
+
     private fun insertResultIntoDb(accountId: Long, result: List<Conversation>?) {
         result?.filter { it.lastStatus != null }
-                ?.map{ it.toEntity(accountId) }
+                ?.map { it.toEntity(accountId) }
                 ?.let { db.conversationDao().insert(it) }
 
     }

--- a/app/src/main/java/tech/bigfig/roma/components/conversation/ConversationsRepository.kt
+++ b/app/src/main/java/tech/bigfig/roma/components/conversation/ConversationsRepository.kt
@@ -1,6 +1,5 @@
 package tech.bigfig.roma.components.conversation
 
-import android.util.Log
 import androidx.annotation.MainThread
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -37,6 +36,7 @@ class ConversationsRepository @Inject constructor(val mastodonApi: MastodonApi, 
 
     @MainThread
     fun refresh(accountId: Long, showLoadingIndicator: Boolean): LiveData<NetworkState> {
+
         val networkState = MutableLiveData<NetworkState>()
         if (showLoadingIndicator) {
             networkState.value = NetworkState.LOADING
@@ -72,25 +72,26 @@ class ConversationsRepository @Inject constructor(val mastodonApi: MastodonApi, 
         val conversations = HashMap<String, Status>()
         val conversationsRecentFirst = HashMap<Date, Status>()
 
-        body?.reversed()?.iterator()?.forEach { it.pleroma?.conversation_id?.let { id -> conversations[id] = it } }
+        body?.reversed()?.iterator()?.forEach {
+            it.pleroma?.conversation_id?.let { id -> conversations[id] = it }
+        }
 
-        conversations.forEach { conversationsRecentFirst[it.value.createdAt] = it.value }
+        conversations.forEach {
+            conversationsRecentFirst[it.value.createdAt] = it.value
+        }
 
         val conversationList = ArrayList<Conversation>()
 
         conversationsRecentFirst.toSortedMap(reverseOrder()).forEach {
-            conversationList.add(
-                    Conversation(
-                            id = it.value.pleroma?.conversation_id!!,
-                            accounts = emptyList(),
-                            lastStatus = it.value,
-                            unread = false
-                    )
-            )
-        }
 
-        conversationList.forEach {
-            Log.v("SFG", "Conversation -> $it")
+            var convoToAdd = Conversation(
+                    id = it.value.pleroma?.conversation_id!!,
+                    accounts = getAccountObjects(it.value.mentions),
+                    lastStatus = it.value,
+                    unread = false
+            )
+
+            conversationList.add(convoToAdd)
         }
 
         return conversationList

--- a/app/src/main/java/tech/bigfig/roma/components/conversation/ConversationsRepository.kt
+++ b/app/src/main/java/tech/bigfig/roma/components/conversation/ConversationsRepository.kt
@@ -30,7 +30,7 @@ class ConversationsRepository @Inject constructor(val mastodonApi: MastodonApi, 
 
     private val ioExecutor = Executors.newSingleThreadExecutor()
 
-    data class ConversationHolder(var lastFetchedId:String, var conversations:List<Conversation>)
+    data class ConversationHolder(var lastFetchedId: String, var conversations: List<Conversation>)
 
     companion object {
         private const val DEFAULT_PAGE_SIZE = 20

--- a/app/src/main/java/tech/bigfig/roma/entity/Status.kt
+++ b/app/src/main/java/tech/bigfig/roma/entity/Status.kt
@@ -38,6 +38,7 @@ data class Status(
         @SerializedName("spoiler_text") val spoilerText: String,
         val visibility: Visibility,
         @SerializedName("media_attachments") var attachments: ArrayList<Attachment>,
+        val pleroma: StatusPleroma?,
         val mentions: Array<Mention>,
         val application: Application?,
         var pinned: Boolean?,

--- a/app/src/main/java/tech/bigfig/roma/entity/StatusPleroma.kt
+++ b/app/src/main/java/tech/bigfig/roma/entity/StatusPleroma.kt
@@ -1,0 +1,29 @@
+package tech.bigfig.roma.entity
+
+import com.google.gson.annotations.SerializedName
+
+data class StatusPleroma(
+        val content: TextPlain,
+        val conversation_id: String,
+        val in_reply_to_account_acct: String,
+        val local: Boolean,
+        val spoiler_text: TextPlain
+) {
+    data class TextPlain(
+            @SerializedName("text/plain") val text_plain: String
+    )
+}
+
+/*
+
+            "content": {
+                "text/plain": "@jamzy Whut?"
+            },
+            "conversation_id": 45142525,
+            "in_reply_to_account_acct": "jamzy",
+            "local": false,
+            "spoiler_text": {
+                "text/plain": ""
+            }
+
+ */

--- a/app/src/main/java/tech/bigfig/roma/entity/StatusPleroma.kt
+++ b/app/src/main/java/tech/bigfig/roma/entity/StatusPleroma.kt
@@ -13,17 +13,3 @@ data class StatusPleroma(
             @SerializedName("text/plain") val text_plain: String
     )
 }
-
-/*
-
-            "content": {
-                "text/plain": "@jamzy Whut?"
-            },
-            "conversation_id": 45142525,
-            "in_reply_to_account_acct": "jamzy",
-            "local": false,
-            "spoiler_text": {
-                "text/plain": ""
-            }
-
- */

--- a/app/src/main/java/tech/bigfig/roma/network/MastodonApi.java
+++ b/app/src/main/java/tech/bigfig/roma/network/MastodonApi.java
@@ -346,8 +346,13 @@ public interface MastodonApi {
     @GET("api/v1/instance")
     Call<Instance> getInstance();
 
-    @GET("/api/v1/conversations")
-    Call<List<Conversation>> getConversations(@Nullable @Query("max_id") String maxId, @Query("limit") int limit);
+    @GET("/api/v1/timelines/direct")
+    Call<List<Status>> getTimelineDirect(
+            @Nullable @Query("max_id") String maxId,
+            @Nullable @Query("since_id") String sinceId,
+            @Query("limit") int limit
+    );
+
     @GET("api/v1/filters")
     Call<List<Filter>> getFilters();
 

--- a/app/src/main/java/tech/bigfig/roma/repository/TimelineRepository.kt
+++ b/app/src/main/java/tech/bigfig/roma/repository/TimelineRepository.kt
@@ -231,6 +231,7 @@ class TimelineRepositoryImpl(
                     pinned = false,
                     poll = poll,
                     card = null,
+                    pleroma = null,
                     repliesCount = status.repliesCount
             )
         }
@@ -258,6 +259,7 @@ class TimelineRepositoryImpl(
                     pinned = false,
                     poll = null,
                     card = null,
+                    pleroma = null,
                     repliesCount = 0
             )
         } else {
@@ -284,6 +286,7 @@ class TimelineRepositoryImpl(
                     pinned = false,
                     poll = poll,
                     card = null,
+                    pleroma = null,
                     repliesCount = status.repliesCount
             )
         }

--- a/app/src/test/java/tech/bigfig/roma/BottomSheetActivityTest.kt
+++ b/app/src/test/java/tech/bigfig/roma/BottomSheetActivityTest.kt
@@ -83,6 +83,7 @@ class BottomSheetActivityTest {
             "",
             Status.Visibility.PUBLIC,
             ArrayList(),
+            null,
             arrayOf(),
             null,
             pinned = false,

--- a/app/src/test/java/tech/bigfig/roma/fragment/TimelineRepositoryTest.kt
+++ b/app/src/test/java/tech/bigfig/roma/fragment/TimelineRepositoryTest.kt
@@ -308,6 +308,7 @@ class TimelineRepositoryTest {
                 reblogged = true,
                 favourited = false,
                 attachments = ArrayList(),
+                pleroma = null,
                 mentions = arrayOf(),
                 application = null,
                 inReplyToAccountId = null,


### PR DESCRIPTION
- Removes the `api/v1/conversations` API call entirely.
- Conversations elements are built up by processing `api/v1/conversations` and converting `Mention` 
 objects to `Account` using `api/v1/accounts/:id`.
- Less invasive port than the previous WIP; no database changes are necessary, which negates issues caused by dropping and rebuilding the Conversations table.