### PR TITLE
Fix/wrong thread SearchFragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,7 +19,7 @@ android {
         applicationId "tech.bigfig.roma"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 97
+        versionCode 98
         versionName "8.1.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -136,6 +136,7 @@ dependencies {
     kapt 'androidx.room:room-compiler:2.1.0'
     implementation 'androidx.room:room-rxjava2:2.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0-RC"
     implementation "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
     implementation "com.google.dagger:dagger-android:$daggerVersion"

--- a/app/src/main/java/tech/bigfig/roma/components/search/fragments/SearchFragment.kt
+++ b/app/src/main/java/tech/bigfig/roma/components/search/fragments/SearchFragment.kt
@@ -23,6 +23,10 @@ import tech.bigfig.roma.di.Injectable
 import tech.bigfig.roma.di.ViewModelFactory
 import tech.bigfig.roma.interfaces.LinkListener
 import kotlinx.android.synthetic.main.fragment_search.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 import tech.bigfig.roma.util.*
 import java.util.*
 import javax.inject.Inject
@@ -138,7 +142,9 @@ abstract class SearchFragment<T> : Fragment(),
 
         // Dismissed here because the RecyclerView bottomProgressBar is shown as soon as the retry begins.
         Timer("DelayDismiss", false).schedule(200) {
-            swipeRefreshLayout.isRefreshing = false
+            MainScope().launch {
+                swipeRefreshLayout.isRefreshing = false
+            }
         }
 
         viewModel.retryAllSearches()


### PR DESCRIPTION
- Fixes intermittent crash on Androud 7.* caused by UI access on wrong thread.
- Added Kotlin Coroutines dependency.
- Used Coroutine to resolve above issue.