### PR TITLE
Bugfix/toast null context

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -174,5 +174,8 @@ dependencies {
     androidTestImplementation 'androidx.test:core:1.2.1-alpha02'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2-alpha02'
     androidTestImplementation 'androidx.test:runner:1.3.0-alpha02'
+
+    // ToastCompat - to prevent isolated BadTokenExceptions in Android 7.1 (25)
+    implementation 'me.drakeet.support:toastcompat:1.1.0'
 }
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/tech/bigfig/roma/ComposeActivity.java
+++ b/app/src/main/java/tech/bigfig/roma/ComposeActivity.java
@@ -69,6 +69,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import me.drakeet.support.toast.ToastCompat;
 import tech.bigfig.roma.adapter.EmojiAdapter;
 import tech.bigfig.roma.adapter.ComposeAutoCompleteAdapter;
 import tech.bigfig.roma.adapter.OnEmojiSelectedListener;
@@ -896,7 +897,7 @@ public final class ComposeActivity
         if (emojiView.getAdapter() != null) {
             if (emojiView.getAdapter().getItemCount() == 0) {
                 String errorMessage = getString(R.string.error_no_custom_emojis, accountManager.getActiveAccount().getDomain());
-                Toast.makeText(this, errorMessage, Toast.LENGTH_SHORT).show();
+                ToastCompat.makeText(this, errorMessage, Toast.LENGTH_SHORT).show();
             } else {
                 if (emojiBehavior.getState() == BottomSheetBehavior.STATE_HIDDEN || emojiBehavior.getState() == BottomSheetBehavior.STATE_COLLAPSED) {
                     emojiBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
@@ -1440,7 +1441,7 @@ public final class ComposeActivity
     }
 
     private void showFailedCaptionMessage() {
-        Toast.makeText(this, R.string.error_failed_set_caption, Toast.LENGTH_SHORT).show();
+        ToastCompat.makeText(this, R.string.error_failed_set_caption, Toast.LENGTH_SHORT).show();
     }
 
     private void removeMediaFromQueue(QueuedMedia item) {

--- a/app/src/main/java/tech/bigfig/roma/EmojiPreference.java
+++ b/app/src/main/java/tech/bigfig/roma/EmojiPreference.java
@@ -20,6 +20,7 @@ import android.widget.RadioButton;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import me.drakeet.support.toast.ToastCompat;
 import tech.bigfig.roma.util.EmojiCompatFont;
 
 import java.util.ArrayList;
@@ -144,7 +145,7 @@ public class EmojiPreference extends Preference {
 
             @Override
             public void onFailed() {
-                Toast.makeText(getContext(), R.string.download_failed, Toast.LENGTH_SHORT).show();
+                ToastCompat.makeText(getContext(), R.string.download_failed, Toast.LENGTH_SHORT).show();
                 updateItem(font, container);
             }
         });

--- a/app/src/main/java/tech/bigfig/roma/FiltersActivity.kt
+++ b/app/src/main/java/tech/bigfig/roma/FiltersActivity.kt
@@ -10,6 +10,7 @@ import tech.bigfig.roma.entity.Filter
 import kotlinx.android.synthetic.main.activity_filters.*
 import kotlinx.android.synthetic.main.dialog_filter.*
 import kotlinx.android.synthetic.main.toolbar_basic.*
+import me.drakeet.support.toast.ToastCompat
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.Callback
@@ -43,7 +44,7 @@ class FiltersActivity : BaseActivity(), Injectable {
         api.updateFilter(filter.id, filter.phrase, filter.context, filter.irreversible, filter.wholeWord, filter.expiresAt)
                 .enqueue(object : Callback<Filter> {
                     override fun onFailure(call: Call<Filter>, t: Throwable) {
-                        Toast.makeText(this@FiltersActivity, "Error updating filter '${filter.phrase}'", Toast.LENGTH_SHORT).show()
+                        ToastCompat.makeText(this@FiltersActivity, "Error updating filter '${filter.phrase}'", Toast.LENGTH_SHORT).show()
                     }
 
                     override fun onResponse(call: Call<Filter>, response: Response<Filter>) {
@@ -65,7 +66,7 @@ class FiltersActivity : BaseActivity(), Injectable {
             // This is the only context for this filter; delete it
             api.deleteFilter(filters[itemIndex].id).enqueue(object : Callback<ResponseBody> {
                 override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
-                    Toast.makeText(this@FiltersActivity, "Error updating filter '${filters[itemIndex].phrase}'", Toast.LENGTH_SHORT).show()
+                    ToastCompat.makeText(this@FiltersActivity, "Error updating filter '${filters[itemIndex].phrase}'", Toast.LENGTH_SHORT).show()
                 }
 
                 override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
@@ -94,7 +95,7 @@ class FiltersActivity : BaseActivity(), Injectable {
             }
 
             override fun onFailure(call: Call<Filter>, t: Throwable) {
-                Toast.makeText(this@FiltersActivity, "Error creating filter '$phrase'", Toast.LENGTH_SHORT).show()
+                ToastCompat.makeText(this@FiltersActivity, "Error creating filter '$phrase'", Toast.LENGTH_SHORT).show()
             }
         })
     }

--- a/app/src/main/java/tech/bigfig/roma/ViewMediaActivity.kt
+++ b/app/src/main/java/tech/bigfig/roma/ViewMediaActivity.kt
@@ -55,6 +55,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 
 import kotlinx.android.synthetic.main.activity_view_media.*
+import me.drakeet.support.toast.ToastCompat
 
 import java.io.File
 import java.io.FileNotFoundException
@@ -206,7 +207,7 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
     private fun downloadMedia() {
         val url = attachments!![viewPager.currentItem].attachment.url
         val filename = Uri.parse(url).lastPathSegment
-        Toast.makeText(applicationContext, resources.getString(R.string.download_image, filename), Toast.LENGTH_SHORT).show()
+        ToastCompat.makeText(applicationContext, resources.getString(R.string.download_image, filename), Toast.LENGTH_SHORT).show()
 
         val downloadManager = getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
         val request = DownloadManager.Request(Uri.parse(url))

--- a/app/src/main/java/tech/bigfig/roma/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/tech/bigfig/roma/adapter/StatusBaseViewHolder.java
@@ -33,6 +33,7 @@ import java.util.Objects;
 import at.connyduck.sparkbutton.SparkButton;
 import at.connyduck.sparkbutton.SparkEventListener;
 import kotlin.collections.CollectionsKt;
+import me.drakeet.support.toast.ToastCompat;
 import tech.bigfig.roma.R;
 import tech.bigfig.roma.entity.Attachment;
 import tech.bigfig.roma.entity.Attachment.Focus;
@@ -534,7 +535,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         });
         view.setOnLongClickListener(v -> {
             CharSequence description = getAttachmentDescription(view.getContext(), attachment);
-            Toast.makeText(view.getContext(), description, Toast.LENGTH_LONG).show();
+            ToastCompat.makeText(view.getContext(), description, Toast.LENGTH_LONG).show();
             return true;
         });
     }

--- a/app/src/main/java/tech/bigfig/roma/adapter/StatusDetailedViewHolder.java
+++ b/app/src/main/java/tech/bigfig/roma/adapter/StatusDetailedViewHolder.java
@@ -18,6 +18,7 @@ import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.resource.bitmap.CenterCrop;
+import me.drakeet.support.toast.ToastCompat;
 import tech.bigfig.roma.R;
 import tech.bigfig.roma.entity.Card;
 import tech.bigfig.roma.entity.Status;
@@ -145,7 +146,7 @@ class StatusDetailedViewHolder extends StatusBaseViewHolder {
                 ClipData clip = ClipData.newPlainText("toot", textView.getText());
                 clipboard.setPrimaryClip(clip);
 
-                Toast.makeText(view.getContext(), R.string.copy_to_clipboard_success, Toast.LENGTH_SHORT).show();
+                ToastCompat.makeText(view.getContext(), R.string.copy_to_clipboard_success, Toast.LENGTH_SHORT).show();
 
                 return true;
             };

--- a/app/src/main/java/tech/bigfig/roma/components/chat/ChatActivity.kt
+++ b/app/src/main/java/tech/bigfig/roma/components/chat/ChatActivity.kt
@@ -39,6 +39,7 @@ import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
+import me.drakeet.support.toast.ToastCompat
 import tech.bigfig.roma.*
 import tech.bigfig.roma.components.chat.adapter.ChatAdapter
 import tech.bigfig.roma.databinding.ActivityChatBinding
@@ -208,7 +209,7 @@ class ChatActivity : BaseActivity(), HasAndroidInjector, ClickHandler, AdapterLi
     }
 
     private fun showToast(errorId: Int) {
-        Toast.makeText(this, errorId, Toast.LENGTH_LONG).show()
+        ToastCompat.makeText(this, errorId, Toast.LENGTH_LONG).show()
     }
 
     override fun onSendClick() {

--- a/app/src/main/java/tech/bigfig/roma/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/tech/bigfig/roma/components/search/fragments/SearchStatusesFragment.kt
@@ -50,6 +50,7 @@ import tech.bigfig.roma.util.NetworkState
 import tech.bigfig.roma.viewdata.AttachmentViewData
 import tech.bigfig.roma.viewdata.StatusViewData
 import kotlinx.android.synthetic.main.fragment_search.*
+import me.drakeet.support.toast.ToastCompat
 import tech.bigfig.roma.*
 import java.util.*
 
@@ -344,7 +345,7 @@ class SearchStatusesFragment : SearchFragment<Pair<Status, StatusViewData.Concre
     }
 
     private fun downloadAllMedia(status: Status) {
-        Toast.makeText(context, R.string.downloading_media, Toast.LENGTH_SHORT).show()
+        ToastCompat.makeText(context, R.string.downloading_media, Toast.LENGTH_SHORT).show()
         for ((_, url) in status.attachments) {
             val uri = Uri.parse(url)
             val filename = uri.lastPathSegment
@@ -362,7 +363,7 @@ class SearchStatusesFragment : SearchFragment<Pair<Status, StatusViewData.Concre
             if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 downloadAllMedia(status)
             } else {
-                Toast.makeText(context, R.string.error_media_download_permission, Toast.LENGTH_SHORT).show()
+                ToastCompat.makeText(context, R.string.error_media_download_permission, Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/java/tech/bigfig/roma/fragment/SFragment.java
+++ b/app/src/main/java/tech/bigfig/roma/fragment/SFragment.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
+import me.drakeet.support.toast.ToastCompat;
 import tech.bigfig.roma.BaseActivity;
 import tech.bigfig.roma.BottomSheetActivity;
 import tech.bigfig.roma.ComposeActivity;
@@ -413,7 +414,7 @@ public abstract class SFragment extends BaseFragment implements Injectable {
     }
 
     private void downloadAllMedia(Status status) {
-        Toast.makeText(getContext(), R.string.downloading_media, Toast.LENGTH_SHORT).show();
+        ToastCompat.makeText(getContext(), R.string.downloading_media, Toast.LENGTH_SHORT).show();
         for (Attachment attachment : status.getAttachments()) {
             String url = attachment.getUrl();
             Uri uri = Uri.parse(url);
@@ -432,7 +433,7 @@ public abstract class SFragment extends BaseFragment implements Injectable {
             if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 downloadAllMedia(status);
             } else {
-                Toast.makeText(getContext(), R.string.error_media_download_permission, Toast.LENGTH_SHORT).show();
+                ToastCompat.makeText(getContext(), R.string.error_media_download_permission, Toast.LENGTH_SHORT).show();
             }
         });
     }


### PR DESCRIPTION
As we're still seeing some isolated crashes on Android 7.1.*, this replaces all `Toast.makeText` uses with `ToastCompat.makeText`; avoids potential API-level-specific `android.view.ViewRootImpl.setView` crash.